### PR TITLE
[Fix] Typos and content duplication

### DIFF
--- a/docs/documentation-culture/contributing.md
+++ b/docs/documentation-culture/contributing.md
@@ -14,5 +14,3 @@ A `CONTRIBUTING.md` file provides potential contributors with a short guide of h
 **Submitting changes**: the crucial part of the document describing of how to submit pull requests to a repo. Also include here response that contributors will get from the team and how they deal with the response and feedback. Also include here the guidelines and tips that teach contributors how to submit bugs.
 
 **Style guides and coding conventions**: include git commit messages guide, any code guidelines that are used for contribution to this repo.
-
-Here is a [`CONTRIBUTING.md` template](docs-templates/CONTRIBUTING.md).

--- a/docs/documentation-culture/documentation-day.md
+++ b/docs/documentation-culture/documentation-day.md
@@ -28,7 +28,7 @@ Preparation for Documentation Day should begin at least one month before the eve
 * after the introductory meeting, book a time slot for the event and set up a Google Meet session;
 * share informational posts on documentation writing that will be useful during the event;
 * prepare an image outlining the event workflow for participants, which will be shared via posts in Slack channels.
-* announce each update about the event in the following channels: `#dev` and `#documentary`. The final announcements should be made one week and one day before the event;
+* announce each update about the event in the following channels: `#dev`, `#documentary-day` and `#documentary`. The final announcements should be made one week and one day before the event;
 * arrange catering in advance for those attending the event in person.
 * reviewers and the event organizer should support participants via Google Meet and in the `#documentation-day` channel;
 * two days after the event, post the results and recognize the best contributors (if applicable), and distribute a feedback survey;

--- a/docs/documentation-culture/documentation-day.md
+++ b/docs/documentation-culture/documentation-day.md
@@ -28,7 +28,7 @@ Preparation for Documentation Day should begin at least one month before the eve
 * after the introductory meeting, book a time slot for the event and set up a Google Meet session;
 * share informational posts on documentation writing that will be useful during the event;
 * prepare an image outlining the event workflow for participants, which will be shared via posts in Slack channels.
-* announce each update about the event in the following channels: `#dev`, `#documentary-day`, and `#documentary`. The final announcements should be made one week and one day before the event;
+* announce each update about the event in the following channels: `#dev`, `#documentation-day`, and `#documentary`. The final announcements should be made one week and one day before the event;
 * arrange catering in advance for those attending the event in person.
 * reviewers and the event organizer should support participants via Google Meet and in the `#documentation-day` channel;
 * two days after the event, post the results and recognize the best contributors (if applicable), and distribute a feedback survey;

--- a/docs/documentation-culture/documentation-day.md
+++ b/docs/documentation-culture/documentation-day.md
@@ -28,7 +28,7 @@ Preparation for Documentation Day should begin at least one month before the eve
 * after the introductory meeting, book a time slot for the event and set up a Google Meet session;
 * share informational posts on documentation writing that will be useful during the event;
 * prepare an image outlining the event workflow for participants, which will be shared via posts in Slack channels.
-* announce each update about the event in the following channels: `#dev`, `#documentary-day` and `#documentary`. The final announcements should be made one week and one day before the event;
+* announce each update about the event in the following channels: `#dev`, `#documentary-day`, and `#documentary`. The final announcements should be made one week and one day before the event;
 * arrange catering in advance for those attending the event in person.
 * reviewers and the event organizer should support participants via Google Meet and in the `#documentation-day` channel;
 * two days after the event, post the results and recognize the best contributors (if applicable), and distribute a feedback survey;

--- a/docs/documentation-culture/documentation-day.md
+++ b/docs/documentation-culture/documentation-day.md
@@ -28,7 +28,7 @@ Preparation for Documentation Day should begin at least one month before the eve
 * after the introductory meeting, book a time slot for the event and set up a Google Meet session;
 * share informational posts on documentation writing that will be useful during the event;
 * prepare an image outlining the event workflow for participants, which will be shared via posts in Slack channels.
-* announce each update about the event in the following channels: `#dev`, `#documentation-day`, and `#documentary`. The final announcements should be made one week and one day before the event;
+* announce each update about the event in the following channels: `#dev` and `#documentary`. The final announcements should be made one week and one day before the event;
 * arrange catering in advance for those attending the event in person.
 * reviewers and the event organizer should support participants via Google Meet and in the `#documentation-day` channel;
 * two days after the event, post the results and recognize the best contributors (if applicable), and distribute a feedback survey;

--- a/docs/documentation-culture/writing-guideline.md
+++ b/docs/documentation-culture/writing-guideline.md
@@ -287,7 +287,7 @@ Types of `.puml` diagrams:
 
 > **CAUTION**
 >
-> Use gifs, images ot screenshots where it is impossible to create documentation without them. Applying them it is always expensive for the following documentation support, so please think twice.
+> Use gifs, images or screenshots where it is impossible to create documentation without them. Applying them it is always expensive for the following documentation support, so please think twice.
 
 * for every image provide alt text (the context before an image) that summarize the intent of an image;
 * each image should have a figure caption — a sentence under an image without a period at the end of describing sentence;

--- a/docs/software-architecture/architecture-committee.md
+++ b/docs/software-architecture/architecture-committee.md
@@ -40,7 +40,7 @@ All interested employees from inDriver are welcome to attend committee meetings.
 
 ## Scope of Responsibility
 
-New projects, significant technical decisions, and integration interactions must go through a review process with the committee. The review is conducted by the team's tech lead and / or the project's lead developer.
+New projects, significant technical decisions, and integration interactions must go through a review process with the committee.
 
 The review is conducted by the team's tech lead and/or the project's lead developer.
 


### PR DESCRIPTION
This change request resolves the following:
1. A typo "images or screenshot where" in the writing styles doc.
https://github.com/inDriver/handbook/blob/main/docs/documentation-culture/writing-guideline.md
![image](https://github.com/user-attachments/assets/aff550df-8a57-49f8-9570-c6991eb20372)

2. Duplication of content in the architecture committee doc.
https://github.com/inDriver/handbook/blob/17f136244a541494ab5430c4beef9aa4031f9751/docs/software-architecture/architecture-committee.md
![image](https://github.com/user-attachments/assets/842a7914-8bf9-4661-ab88-da71ead39eb0)

3. The broken link of `CONTRIBUTING.md` on contributing doc. It's the unnecessary transition as the document itself is the template.
https://github.com/inDriver/handbook/blob/main/docs/documentation-culture/contributing.md
<img width="407" alt="image" src="https://github.com/user-attachments/assets/33db2207-0762-4e96-bd60-4d4c14cfde95" />